### PR TITLE
updated syntax

### DIFF
--- a/problems/WEC-4Loop-A690.i
+++ b/problems/WEC-4Loop-A690.i
@@ -138,6 +138,12 @@
     family = MONOMIAL
     initial_condition = 0.1
   [../]
+
+  [./OffsetVar]
+    order = CONSTANT
+    family = MONOMIAL
+    initial_condition = 0.0
+  [../]
 []
 
 [Functions]
@@ -245,13 +251,13 @@
   [./Ni-Diffusivity-Aux]
     type = MaterialRealAux
     variable = Ni-Diffusivity
-    property = OxideDiffusivity-Ni
+    property = OxideDiffusivity_Ni
   [../]
 
   [./Fe-Diffusivity-Aux]
     type = MaterialRealAux
     variable = Fe-Diffusivity
-    property = OxideDiffusivity-Fe
+    property = OxideDiffusivity_Fe
   [../]
 
   [./Ni-Metal-Aux]
@@ -297,6 +303,7 @@
     variable = Oxide-Thickness
     prefactor = Thickness-Prefactor
     power = Thickness-Power
+    offset = OffsetVar
   [../]
 []
 
@@ -357,10 +364,10 @@ active = 'Ni_Soluble_ODE Fe_Soluble_ODE'
     block = 0 
 
     temperature = wall_temp
-    prefactor-Ni = Oxide-Prefactor-Ni
-    activation_energy-Ni = Oxide-Activation-Energy-Ni
-    prefactor-Fe = Oxide-Prefactor-Fe
-    activation_energy-Fe = Oxide-Activation-Energy-Fe
+    prefactor_Ni = Oxide-Prefactor-Ni
+    activation_energy_Ni = Oxide-Activation-Energy-Ni
+    prefactor_Fe = Oxide-Prefactor-Fe
+    activation_energy_Fe = Oxide-Activation-Energy-Fe
   [../]
 []
 

--- a/src/auxkernels/OxideThickness.C
+++ b/src/auxkernels/OxideThickness.C
@@ -35,7 +35,7 @@ OxideThickness::OxideThickness(const InputParameters & parameters)
 Real
 OxideThickness::computeValue()
 {
-
+  
   Real thick = _offset[_qp] + (_prefactor[_qp] * std::pow(_t,_power[_qp]));
   return thick;
 }

--- a/src/materials/FakelapOxide.C
+++ b/src/materials/FakelapOxide.C
@@ -21,10 +21,10 @@ InputParameters validParams<FakelapOxide>()
 
   // Many material properties scale with temperature (to be implemented later)
   params.addRequiredCoupledVar("temperature", "Temperature of the current location)");
-  params.addRequiredCoupledVar("prefactor-Ni", "Ni Diffusivity prefactor, which partially determines oxide phase)");
-  params.addRequiredCoupledVar("activation_energy-Ni", "Ni Activation energy, which partially determines oxide phase");
-  params.addRequiredCoupledVar("prefactor-Fe", "Fe Diffusivity prefactor, which partially determines oxide phase)");
-  params.addRequiredCoupledVar("activation_energy-Fe", "Fe Activation energy, which partially determines oxide phase");
+  params.addRequiredCoupledVar("prefactor_Ni", "Ni Diffusivity prefactor, which partially determines oxide phase)");
+  params.addRequiredCoupledVar("activation_energy_Ni", "Ni Activation energy, which partially determines oxide phase");
+  params.addRequiredCoupledVar("prefactor_Fe", "Fe Diffusivity prefactor, which partially determines oxide phase)");
+  params.addRequiredCoupledVar("activation_energy_Fe", "Fe Activation energy, which partially determines oxide phase");
 
   return params;
 }
@@ -34,14 +34,14 @@ FakelapOxide::FakelapOxide(const InputParameters & parameters)
 
      // Bring in any coupled variables needed to calculate material properties
      _T(coupledValue("temperature")),
-     _D_0_Ni(coupledValue("prefactor-Ni")),
-     _E_A_Ni(coupledValue("activation_energy-Ni")),
-     _D_0_Fe(coupledValue("prefactor-Fe")),
-     _E_A_Fe(coupledValue("activation_energy-Fe")),
+     _D_0_Ni(coupledValue("prefactor_Ni")),
+     _E_A_Ni(coupledValue("activation_energy_Ni")),
+     _D_0_Fe(coupledValue("prefactor_Fe")),
+     _E_A_Fe(coupledValue("activation_energy_Fe")),
 
      // Declare material properties that kernels can use
-     _Ni_diffusivity_matprop(declareProperty<Real>("OxideDiffusivity-Ni")),
-     _Fe_diffusivity_matprop(declareProperty<Real>("OxideDiffusivity-Fe")),
+     _Ni_diffusivity_matprop(declareProperty<Real>("OxideDiffusivity_Ni")),
+     _Fe_diffusivity_matprop(declareProperty<Real>("OxideDiffusivity_Fe")),
      _rho_h2o(declareProperty<Real>("WaterDensity"))
 
 {


### PR DESCRIPTION
Updated material property for diffusivity and other parameters in FakelapOxide material object to remove '-' from parameter name. Added variable for OxideThickness offset param to sample input file. 